### PR TITLE
Update LICENSE - change permissions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ MIT License
 
 Copyright (c) 2021 gh-mentor
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
+Permission is hereby granted, at a nominal cost, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell


### PR DESCRIPTION
This pull request includes a small change to the `LICENSE` file. The change updates the terms of the MIT License to indicate that obtaining a copy of the software may involve a nominal cost.

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L5-R5): Modified the permission clause to state "at a nominal cost" instead of "free of charge."