### PR TITLE
Update LICENSE - copyright change

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,8 @@
 MIT License
 
-Copyright (c) 2021 gh-mentor
+Copyright (c) 2024 gh-mentor
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
+Permission is granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell


### PR DESCRIPTION
This pull request includes a small change to the `LICENSE` file. The change updates the copyright year and removes an unnecessary phrase.

Changes to `LICENSE`:

* Updated the copyright year from 2021 to 2024.
* Removed the phrase "hereby" from the permission grant statement.